### PR TITLE
perf: scan with Shape Detection API

### DIFF
--- a/src/worker/jsqr.js
+++ b/src/worker/jsqr.js
@@ -16,20 +16,73 @@ export default () => {
       "https://cdn.jsdelivr.net/npm/jsqr@1.3.1/dist/jsQR.min.js"
     );
 
-    self.addEventListener("message", function(event) {
-      const imageData = event.data;
-      const result = jsQR(imageData.data, imageData.width, imageData.height);
+    const jsqrDetect = async ({ data, width, height }) => {
+      const result = jsQR(data, width, height, {
+        inversionAttempts: "dontInvert"
+      });
 
-      let content = null;
-      let location = null;
-
-      if (result !== null) {
-        content = result.data;
-        location = result.location;
+      if (result === null) {
+        return {
+          content: null,
+          location: null
+        };
+      } else {
+        return {
+          content: result.data,
+          location: result.location
+        };
       }
+    };
 
-      const message = { content, location, imageData };
-      self.postMessage(message, [imageData.data.buffer]);
+    const nativeDetect = async imageData => {
+      const detector = new BarcodeDetector({
+        formats: ["qr_code"]
+      });
+
+      try {
+        const [result] = await detector.detect(imageData);
+
+        if (result === undefined) {
+          return {
+            content: null,
+            location: null
+          };
+        } else {
+          const [
+            topLeftCorner,
+            topRightCorner,
+            bottomRightCorner,
+            bottomLeftCorner
+          ] = result.cornerPoints;
+
+          return {
+            content: result.rawValue,
+            location: {
+              topLeftCorner,
+              topRightCorner,
+              bottomRightCorner,
+              bottomLeftCorner,
+
+              // not supported by native API
+              topRightFinderPattern: {},
+              topLeftFinderPattern: {},
+              bottomLeftFinderPattern: {}
+            }
+          };
+        }
+      } catch (error) {
+        console.error("Boo, BarcodeDetection failed: " + error);
+      }
+    };
+
+    const detect = self.BarcodeDetector === undefined ? jsqrDetect : nativeDetect;
+
+    self.addEventListener("message", async event => {
+      const imageData = event.data;
+
+      const { content, location } = await detect(imageData);
+
+      self.postMessage({ content, location, imageData }, [imageData.data.buffer]);
     });
   });
   /* eslint-enable */


### PR DESCRIPTION
The new Shape Detection API comes with native QR code scanning Support.
On supporting devices this should vastly improve scanning performance.
Also `jsQR` is not required on these devices so its not included
anymore, making the bunlde 127kB lighter. `jsQR` is still loaded but
from the Worker via `importScripts`.

Issue: #162